### PR TITLE
use cmucal humble-base image instead of ros:humble image to fix GPG key error

### DIFF
--- a/buildkitd.toml
+++ b/buildkitd.toml
@@ -1,0 +1,7 @@
+[registry."registry:5000"]
+http = true
+insecure = true
+
+# setting for low powered machines
+#[worker.oci]
+#  max-parallelism = 1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,8 @@ services:
       context: ./docker/client
       additional_contexts:
         cabot_src: ./
+      args:
+        - BASE_IMAGE=${BASE_IMAGE:-cabot-base}
       x-bake:
         tags:
           - ${REGISTRY:-cmucal}/cabot-influxdb-client

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,4 +1,9 @@
-FROM ros:humble AS base
+ARG BASE_IMAGE=cabot-base
+ARG FROM_IMAGE=cmucal/${BASE_IMAGE}:humble-base
+
+FROM ${FROM_IMAGE} AS base
+
+ARG TARGETARCH
 
 RUN apt update && apt install --no-install-recommends -y \
     curl \
@@ -8,6 +13,16 @@ RUN apt update && apt install --no-install-recommends -y \
     ros-humble-cv-bridge \
     && \	
     rm -rf /var/lib/apt/lists/*
+
+# downgrade libopencv-dev for ROS2
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+        apt update && apt install -q -y --no-install-recommends --allow-downgrades \
+        libopencv-dev=4.5.4+dfsg-9ubuntu4 \
+        && \
+        apt clean && \
+        rm -rf /var/lib/apt/lists/* \
+        ; \
+    fi
 
 RUN pip3 install \
     influxdb-client \


### PR DESCRIPTION
- use cmucal humble-base image instead of ros:humble image to fix GPG key error
- add buildkitd.toml

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>